### PR TITLE
Add support for Windows build and instructions

### DIFF
--- a/.github/workflows/build-helper.yml
+++ b/.github/workflows/build-helper.yml
@@ -16,6 +16,10 @@ jobs:
                       arch: "amd64"
                       runner: "ubuntu-latest"
                       scripthaus: "build-package-linux"
+                    - platform: "windows"
+                      arch: "x64"
+                      runner: "windows-latest"
+                      scripthaus: "build-package-windows"
         runs-on: ${{ matrix.runner }}
         steps:
             - uses: actions/checkout@v4

--- a/BUILD-WINDOWS.md
+++ b/BUILD-WINDOWS.md
@@ -1,0 +1,57 @@
+# Building Wave Terminal on Windows
+
+This document provides instructions for setting up the development environment for Wave Terminal on Windows.
+
+## Prerequisites
+
+Before you begin, ensure you have the following installed:
+- Git
+- Node.js (LTS version recommended)
+- Yarn
+- Go (version 1.18 or higher)
+
+## Cloning the Repository
+
+To clone the Wave Terminal repository, open a command prompt or PowerShell and run:
+
+```
+git clone https://github.com/tribixbite/waveterm.git
+cd waveterm
+```
+
+## Setting Up the Development Environment
+
+1. Install the required Node.js dependencies by running:
+
+```
+yarn install
+```
+
+2. Build the Electron application:
+
+```
+yarn run build:windows
+```
+
+This command will compile the TypeScript code and package the application for Windows.
+
+3. To start the application in development mode, use:
+
+```
+yarn run start:windows
+```
+
+## Environment Variables and Path Adjustments
+
+Ensure that the paths to Git, Node.js, Yarn, and Go are correctly set in your system's environment variables. This will allow you to run the necessary commands from any command prompt or PowerShell window.
+
+## Troubleshooting
+
+If you encounter issues during the setup, consider the following tips:
+
+- Ensure all prerequisites are correctly installed and up to date.
+- Check the environment variables to ensure paths are correctly set.
+- For issues related to Yarn or Node.js dependencies, try removing the `node_modules` folder and running `yarn install` again.
+- Consult the official documentation for Git, Node.js, Yarn, and Go for platform-specific setup instructions.
+
+For further assistance, please open an issue on the GitHub repository.

--- a/build-linux.md
+++ b/build-linux.md
@@ -1,5 +1,7 @@
 # Build Instructions for Wave Terminal on Linux
 
+> **Note for Windows users:** For instructions on setting up the development environment on Windows, please see [Windows Build Instructions](./BUILD-WINDOWS.md).
+
 These instructions are for setting up the build on Linux (Ubuntu).
 If you're developing on MacOS please use the [MacOS Build Instructions](./BUILD.md).
 If you are working on a different Linux distribution, you may need to adapt some of these instructions to fit your environment.

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -83,6 +83,20 @@ const config = {
             category: "Development;Utility;",
         },
     },
+    win: {
+        target: "nsis",
+        icon: "public/waveterm.ico",
+        legalTrademarks: "WaveTerm is a trademark of Command Line Inc.",
+        publisherName: "Command Line Inc.",
+        fileAssociations: [
+            {
+                ext: "wtscript",
+                name: "WaveTerm Script",
+                description: "WaveTerm Script File",
+                icon: "public/waveterm.ico"
+            }
+        ]
+    },
     appImage: {
         license: "LICENSE",
     },

--- a/package.json
+++ b/package.json
@@ -109,7 +109,9 @@
         "yaml": "^2.4.0"
     },
     "scripts": {
-        "postinstall": "electron-builder install-app-deps"
+        "postinstall": "electron-builder install-app-deps",
+        "build:windows": "yarn run build && electron-builder build --windows",
+        "start:windows": "electron ."
     },
     "packageManager": "yarn@4.1.1"
 }


### PR DESCRIPTION
This pull request introduces comprehensive support for building and running Wave Terminal on Windows, alongside improvements to the existing Linux build instructions and automation enhancements for cross-platform compatibility.

- **Windows Support:**
  - Adds `BUILD-WINDOWS.md` with detailed instructions for setting up the development environment on Windows, including prerequisites, cloning the repository, and build commands.
  - Updates `package.json` to include new scripts `build:windows` and `start:windows` for building and running the application on Windows.
  - Modifies `electron-builder.config.js` to add configuration for Windows build targets, specifying the icon file and Windows-specific build options such as file associations.

- **Documentation and Build Instructions:**
  - Updates `build-linux.md` to direct Windows users to the new Windows build instructions, ensuring clarity and accessibility for developers on different platforms.

- **Automation and Compatibility:**
  - Enhances `.github/workflows/build-helper.yml` by adding a new job for Windows build automation using GitHub Actions, configured to run on a Windows runner. This ensures ongoing compatibility and ease of build process across platforms.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tribixbite/waveterm?shareId=bf60ce19-808e-4441-971e-d59676f749f2).